### PR TITLE
Fix OpenAI API key config lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To configure Quill, follow the steps below:
    ```yaml
    preferences:
      openai:
-       apikey: "your-api-key-here"
+       apiKey: "your-api-key-here"
        model: "gpt-4o-mini"
      ollama:
        apiUrl: "http://localhost:11434/api/generate"

--- a/service/openai_client.go
+++ b/service/openai_client.go
@@ -17,12 +17,12 @@ type OpenAIClient struct {
 }
 
 func NewOpenAIClient(model string) *OpenAIClient {
-	apiKey := viper.GetString("preferences.openai.apikey")
+	apiKey := viper.GetString("preferences.openai.apiKey")
 	cli := openai.NewClient(option.WithAPIKey(apiKey))
 
 	if apiKey == "" {
 		logger.InitLogger("pretty")
-		logger.L().Error("OpenAI API key not configured. Set preferences.openai.apikey in config or set --apikey flag.")
+		logger.L().Error("OpenAI API key not configured. Set preferences.openai.apiKey in config or set --apikey flag.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary
- use `apiKey` instead of `apikey` when loading OpenAI credentials
- update example config in README

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684095c05e00832fb5215e76f80cbfc1