### PR TITLE
Fix config section numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To configure Quill, follow the steps below:
      providerDefault: "openai"
    ```
 
-4. **Set your credentials:**
+2. **Set your credentials:**
    You can set the OpenAI API key and default model using the commands:
    ```bash
    quill config --set-openai-api-key "your-api-key-here"


### PR DESCRIPTION
## Summary
- fix numbering for credentials section

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68409b2b2a84832fae14f7ff23efc84c