### PR TITLE
Update OpenAI API key setup guidance

### DIFF
--- a/service/openai_client.go
+++ b/service/openai_client.go
@@ -22,7 +22,7 @@ func NewOpenAIClient(model string) *OpenAIClient {
 
 	if apiKey == "" {
 		logger.InitLogger("pretty")
-		logger.L().Error("OpenAI API key not configured. Set preferences.openai.apiKey in config or set --apikey flag.")
+		logger.L().Error("OpenAI API key not configured. Run `quill config --set-openai-api-key` or edit the config file.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary
- show clearer instructions when OpenAI API key is missing

## Testing
- `go test ./...` *(fails: access to module proxy forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68409b627428832f8eb194a424d0ced2