### PR TITLE
Fix config key for API credentials

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -48,7 +48,7 @@ func initializeConfig(configPath string) error {
 	viper.Set("preferences", map[string]interface{}{
 		"providerDefault": "",
 		"openai": map[string]interface{}{
-			"apiKey": "",
+			"apikey": "",
 			"model":  "",
 		},
 		"ollama": map[string]interface{}{
@@ -56,7 +56,7 @@ func initializeConfig(configPath string) error {
 			"model":  "",
 		},
 		"gemini": map[string]interface{}{
-			"apiKey": "",
+			"apikey": "",
 			"model":  "",
 		},
 	})
@@ -117,7 +117,7 @@ var configCmd = &cobra.Command{
 		}
 
 		if setOpenAIApiKey != "" {
-			viper.Set("preferences.openai.apiKey", setOpenAIApiKey)
+			viper.Set("preferences.openai.apikey", setOpenAIApiKey)
 			logger.InitLogger("pretty")
 			logger.L().Info("Setting OpenAI API key.")
 			changes++

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -31,7 +31,7 @@ func TestConfigFlags(t *testing.T) {
 	cmd.Flags().Set("set-openai-api-key", "sk-1234567890")
 	err = cmd.Execute()
 	assert.NoError(t, err)
-	assert.Equal(t, "sk-1234567890", viper.GetString("preferences.openai.apiKey"))
+	assert.Equal(t, "sk-1234567890", viper.GetString("preferences.openai.apikey"))
 
 	cmd.Flags().Set("set-openai-model", "gpt-4o-mini")
 	err = cmd.Execute()


### PR DESCRIPTION
## Summary
- align OpenAI and Gemini API key field names in the config
- adjust tests to match the new key name

## Testing
- `go test ./...` *(fails: downloading modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68409f19bd74832fae5f45cea97e8806